### PR TITLE
Improve changes of getPropertyOwnerDetails

### DIFF
--- a/contracts/JTCRETToken.sol
+++ b/contracts/JTCRETToken.sol
@@ -61,9 +61,12 @@ contract JTCRETToken is StandardToken {
        } else { return false; }
     }
 
-    function getPropertyCurrentOwnerDetails(string _propertyAddress) constant returns (string ownerName, string ownerEmail, address walletAddress) {
-        require(propertyTransferDetails[_propertyAddress].length > 0);
-        uint lastIndex = propertyTransferDetails[_propertyAddress].length - 1;
-        return (propertyTransferDetails[_propertyAddress][lastIndex].owner.name, propertyTransferDetails[_propertyAddress][lastIndex].owner.email, propertyTransferDetails[_propertyAddress][lastIndex].owner.walletAddress);
+    function getPropertyOwnerDetails(string _propertyAddress, uint index) constant returns (string ownerName, string ownerEmail, address ownerWalletAddress, string deedURL) {
+        uint length = propertyTransferDetails[_propertyAddress].length;
+        require(length > 0);
+        require(length >= index);
+        uint requestedIndex = length - index;
+        return (propertyTransferDetails[_propertyAddress][requestedIndex].owner.name, propertyTransferDetails[_propertyAddress][requestedIndex].owner.email,
+          propertyTransferDetails[_propertyAddress][requestedIndex].owner.walletAddress, propertyTransferDetails[_propertyAddress][requestedIndex].deedURL);
     }
 }

--- a/contracts/JTCRETToken.sol
+++ b/contracts/JTCRETToken.sol
@@ -61,12 +61,20 @@ contract JTCRETToken is StandardToken {
        } else { return false; }
     }
 
-    function getPropertyOwnerDetails(string _propertyAddress, uint index) constant returns (string ownerName, string ownerEmail, address ownerWalletAddress, string deedURL) {
+    function getPropertyOwnerDetails(string _propertyAddress, uint index) constant returns (string ownerName, string ownerEmail, address ownerWalletAddress, string deedURL, bool _previousIndexExist, bool _nextIndexExist) {
         uint length = propertyTransferDetails[_propertyAddress].length;
         require(length > 0);
         require(length >= index);
         uint requestedIndex = length - index;
+        bool previousIndexExist = false;
+        bool nextIndexExist = false;
+        if (length >= (index + 1) && (index + 1) > 0) {
+            previousIndexExist = true;
+        }
+        if (length >= (index - 1) && (index - 1) > 0) {
+            nextIndexExist = true;
+        }
         return (propertyTransferDetails[_propertyAddress][requestedIndex].owner.name, propertyTransferDetails[_propertyAddress][requestedIndex].owner.email,
-          propertyTransferDetails[_propertyAddress][requestedIndex].owner.walletAddress, propertyTransferDetails[_propertyAddress][requestedIndex].deedURL);
+          propertyTransferDetails[_propertyAddress][requestedIndex].owner.walletAddress, propertyTransferDetails[_propertyAddress][requestedIndex].deedURL, previousIndexExist, nextIndexExist);
     }
 }


### PR DESCRIPTION
## Description
_Improve changes of getPropertyOwnerDetails function, made it global which is used to get any owner detail by using indexing. Index 1 returns the current owner, previous by index 2 and so on._

## Tests

### Manual test cases run
1. Tried to access the owner details at index which doesn't exist, then function returns error message.
2. If current owner of the property is trying to transfer property to owner wallet address then only allow else throws error message.
3. Only allowing index value greater than 0, else return error message